### PR TITLE
Add 'docker' to labeler config

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,7 +1,17 @@
 api:
   - changed-files:
-      - any-glob-to-any-file: "api/*"
+      - all-globs-to-any-file: 
+        - "api/*"
+        - "!api/Dockerfile"
 
 web:
   - changed-files:
-      - any-glob-to-any-file: "web/*"
+      - all-glob-to-any-file:
+        - "web/*"
+        - "!web/Dockerfile"
+
+docker:
+  - changed-files:
+    - any-glob-to-any-file: 
+      - "**/Docker"
+      - "compose.yaml"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -6,7 +6,7 @@ api:
 
 web:
   - changed-files:
-      - all-glob-to-any-file:
+      - all-globs-to-any-file:
         - "web/*"
         - "!web/Dockerfile"
 


### PR DESCRIPTION
The new `docker` label applies to changes affecting Docker or Docker Compose, and doesn't automatically add the `api` or `web` labels to changes in their Dockerfiles. 