### PR TITLE
Unpin API dependencies

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -11,15 +11,15 @@ authors = [
     "Molly Rose",
     "Jess Muskin-Pierret",
 ]
-requires-python = "~=3.13.2"
+requires-python = "~=3.13"
 dependencies = [
-    "asyncpg==0.30.0",
-    "fastapi==0.115.11",
-    "granian==2.0.1",
-    "pydantic==2.10.6",
-    "pydantic-settings==2.8.1",
-    "sqlalchemy[asyncio]==2.0.38",
-    "sqlmodel==0.0.24",
+    "asyncpg>=0.30.0",
+    "fastapi>=0.115.11",
+    "granian>=2.0.1",
+    "pydantic>=2.10.6",
+    "pydantic-settings>=2.8.1",
+    "sqlalchemy[asyncio]>=2.0.38",
+    "sqlmodel>=0.0.24",
 ]
 
 [dependency-groups]
@@ -29,13 +29,13 @@ dev = [
     {include-group = "test"},
 ]
 mypy = [
-    "mypy[faster-cache]==1.15.0",
+    "mypy[faster-cache]>=1.15.0",
 ]
 test = [
-    "aiosqlite==0.21.0",
-    "httpx==0.28.1",
-    "pytest==8.3.5",
-    "pytest-randomly==3.16.0",
+    "aiosqlite>=0.21",
+    "httpx>=0.28.1",
+    "pytest>=8.3.5",
+    "pytest-randomly>=3.16.0",
 ]
 
 [tool.pytest.ini_options]

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 1
-requires-python = ">=3.13.2, <3.14"
+requires-python = ">=3.13, <4"
 
 [[package]]
 name = "aiosqlite"
@@ -96,29 +96,29 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "asyncpg", specifier = "==0.30.0" },
-    { name = "fastapi", specifier = "==0.115.11" },
-    { name = "granian", specifier = "==2.0.1" },
-    { name = "pydantic", specifier = "==2.10.6" },
-    { name = "pydantic-settings", specifier = "==2.8.1" },
-    { name = "sqlalchemy", extras = ["asyncio"], specifier = "==2.0.38" },
-    { name = "sqlmodel", specifier = "==0.0.24" },
+    { name = "asyncpg", specifier = ">=0.30.0" },
+    { name = "fastapi", specifier = ">=0.115.11" },
+    { name = "granian", specifier = ">=2.0.1" },
+    { name = "pydantic", specifier = ">=2.10.6" },
+    { name = "pydantic-settings", specifier = ">=2.8.1" },
+    { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.38" },
+    { name = "sqlmodel", specifier = ">=0.0.24" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "aiosqlite", specifier = "==0.21.0" },
-    { name = "httpx", specifier = "==0.28.1" },
-    { name = "mypy", extras = ["faster-cache"], specifier = "==1.15.0" },
-    { name = "pytest", specifier = "==8.3.5" },
+    { name = "aiosqlite", specifier = ">=0.21" },
+    { name = "httpx", specifier = ">=0.28.1" },
+    { name = "mypy", extras = ["faster-cache"], specifier = ">=1.15.0" },
+    { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-randomly", specifier = ">=3.16.0" },
     { name = "ruff", specifier = "==0.9.10" },
 ]
-mypy = [{ name = "mypy", extras = ["faster-cache"], specifier = "==1.15.0" }]
+mypy = [{ name = "mypy", extras = ["faster-cache"], specifier = ">=1.15.0" }]
 test = [
-    { name = "aiosqlite", specifier = "==0.21.0" },
-    { name = "httpx", specifier = "==0.28.1" },
-    { name = "pytest", specifier = "==8.3.5" },
+    { name = "aiosqlite", specifier = ">=0.21" },
+    { name = "httpx", specifier = ">=0.28.1" },
+    { name = "pytest", specifier = ">=8.3.5" },
     { name = "pytest-randomly", specifier = ">=3.16.0" },
 ]
 
@@ -460,7 +460,7 @@ name = "sqlalchemy"
 version = "2.0.38"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
+    { name = "greenlet", marker = "(python_full_version < '3.14' and platform_machine == 'AMD64') or (python_full_version < '3.14' and platform_machine == 'WIN32') or (python_full_version < '3.14' and platform_machine == 'aarch64') or (python_full_version < '3.14' and platform_machine == 'amd64') or (python_full_version < '3.14' and platform_machine == 'ppc64le') or (python_full_version < '3.14' and platform_machine == 'win32') or (python_full_version < '3.14' and platform_machine == 'x86_64')" },
     { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e4/08/9a90962ea72acd532bda71249a626344d855c4032603924b1b547694b837/sqlalchemy-2.0.38.tar.gz", hash = "sha256:e5a4d82bdb4bf1ac1285a68eab02d253ab73355d9f0fe725a97e1e0fa689decb", size = 9634782 }


### PR DESCRIPTION
Unpin all the API dependencies, except ruff, which needs an exact version for CI. This lets us actually update dependencies. Use `uv sync --frozen` for a reproducable build.